### PR TITLE
ST-58: Write tests for route: GET /classrooms/:classroom_id/messages

### DIFF
--- a/test/controllers/api/v1/classrooms/global_messages_controller_test.rb
+++ b/test/controllers/api/v1/classrooms/global_messages_controller_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Api::V1::Classrooms::GlobalMessagesControllerTest < ActionController::TestCase
+    setup :setup_controller_with_fake_user
+
+    def setup
+        @user = users(:teacher_user)
+        @classroom = classrooms(:classroom_one)
+    end
+
+    test "#index responds with success" do
+        interactor_result = mock
+        interactor_result.expects(:success?).returns(true)
+        interactor_result.expects(:messages).returns([])
+
+        Classrooms::GlobalMessages::GetMessagesFlow.expects(:call).returns(interactor_result)
+
+        get :index, params: { classroom_id: 1 }
+
+        assert_response :ok
+    end
+
+    test "#index does not respond with success" do
+        interactor_result = mock
+        interactor_result.expects(:success?).returns(false)
+        interactor_result.expects(:message).returns("some error message")
+
+        Classrooms::GlobalMessages::GetMessagesFlow.expects(:call).returns(interactor_result)
+
+        get :index, params: { classroom_id: 1 }
+
+        assert_response :unprocessable_entity
+    end
+end

--- a/test/fixtures/classroom_global_messages.yml
+++ b/test/fixtures/classroom_global_messages.yml
@@ -1,0 +1,5 @@
+message_one:
+  id: 1
+  user_id: 1
+  classroom_id: 1
+  text: "Test message"

--- a/test/interactors/classrooms/global_messages/broadcast_message_test.rb
+++ b/test/interactors/classrooms/global_messages/broadcast_message_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class Classrooms::GlobalMessages::BroadcastMessageTest < ActiveSupport::TestCase
+    def setup
+        @classroom = classrooms(:classroom_one)
+        @message = classroom_global_messages(:message_one)
+    end
+
+    test "should broadcast message successfully" do
+        result = Classrooms::GlobalMessages::BroadcastMessage.call(classroom_id: @classroom.id, new_message: @message)
+
+        assert result.success?
+    end
+
+    test "should fail to broadcast message without required parameters" do
+        result = Classrooms::GlobalMessages::BroadcastMessage.call(classroom_id: nil, new_message: nil)
+
+        assert_not result.success?
+    end
+end

--- a/test/interactors/classrooms/global_messages/create_message_flow_test.rb
+++ b/test/interactors/classrooms/global_messages/create_message_flow_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class Classrooms::GlobalMessages::CreateMessageFlowTest < ActiveSupport::TestCase
+  test "#call all required interactors" do
+    assert_equal Classrooms::GlobalMessages::CreateMessageFlow.organized, [
+      Shared::FindClassroom,
+      Shared::ValidateUserAccess,
+      Classrooms::GlobalMessages::CreateMessage,
+      Classrooms::GlobalMessages::BroadcastMessage
+    ]
+  end
+end

--- a/test/interactors/classrooms/global_messages/create_message_test.rb
+++ b/test/interactors/classrooms/global_messages/create_message_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Classrooms::GlobalMessages::CreateMessageTest < ActiveSupport::TestCase
+    def setup
+        @params = {
+            user_id: users(:teacher_user).id,
+            classroom_id: classrooms(:classroom_one).id,
+            text: "Test message"
+        }
+    end
+
+    test "should create a new message with valid parameters" do
+        interactor_result = Classrooms::GlobalMessages::CreateMessage.call(params: @params)
+
+        assert interactor_result.success?
+        assert_not_nil interactor_result.new_message
+        assert interactor_result.new_message.persisted?
+    end
+
+    test "should fail to create message with invalid parameters" do
+        invalid_params = { user_id: nil, classroom_id: nil, text: nil }
+
+        interactor_result = Classrooms::GlobalMessages::CreateMessage.call(params: invalid_params)
+
+        assert_not interactor_result.success?
+        assert_nil interactor_result.new_message
+        assert_equal interactor_result.message, "Failed to create message"
+        assert_equal interactor_result.status, :unprocessable_entity
+    end
+end

--- a/test/models/classroom_global_message_test.rb
+++ b/test/models/classroom_global_message_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class ClassroomGlobalMessageTest < ActiveSupport::TestCase
+    should belong_to(:classroom)
+    should belong_to(:user)
+
+    should validate_presence_of(:text)
+    should validate_length_of(:text).is_at_most(10000)
+    should validate_presence_of(:user_id)
+    should validate_presence_of(:classroom_id)
+
+    test "message is created with validations passing" do
+        classroom = classrooms(:classroom_one)
+        user = users(:teacher_user)
+        valid_message = ClassroomGlobalMessage.new(
+            text: "Valid message text",
+            classroom_id: classroom.id,
+            user_id: user.id
+        )
+
+        assert valid_message.valid?
+        assert_empty valid_message.errors
+    end
+
+    test "message fails to create with validations failing" do
+        invalid_message = ClassroomGlobalMessage.new
+
+        assert_not invalid_message.valid?
+        assert_not_empty invalid_message.errors[:text]
+        assert_not_empty invalid_message.errors[:classroom_id]
+        assert_not_empty invalid_message.errors[:user_id]
+    end
+end

--- a/test/policies/classrooms/global_message_policy_test.rb
+++ b/test/policies/classrooms/global_message_policy_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class Classrooms::GlobalMessagePolicyTest < ActiveSupport::TestCase
+    def setup
+        @teacher_user = users(:teacher_user)
+        @student_user = users(:student_user)
+    end
+
+    test 'teacher user authorized to call index' do
+        policy = Classrooms::GlobalMessagePolicy.new(@teacher_user, User)
+
+        assert policy.index?
+    end
+
+    test 'student user authorized to call index' do
+        policy = Classrooms::GlobalMessagePolicy.new(@student_user, User)
+
+        assert policy.index?
+    end
+end

--- a/test/serializers/global_message_serializer_test.rb
+++ b/test/serializers/global_message_serializer_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class GlobalMessageSerializerTest < ActiveSupport::TestCase
+    test 'should render correct attributes' do
+        message_data = classroom_global_messages(:message_one)
+
+        serialized_object = GlobalMessageSerializer.new.serialize(message_data)
+        parsed_object = JSON.parse(serialized_object.to_json)
+
+        assert_equal message_data[:text], parsed_object['text']
+        assert_equal message_data[:id], parsed_object['id']
+        assert_equal message_data[:classroom_id], parsed_object['classroom_id']
+        assert_not_nil message_data.user.id
+    end
+end


### PR DESCRIPTION
### Purpose
- Add tests to improve code reliability.

### Changes
- Add tests for create action in global_messages_controller_test.
- Add tests for interactors: create_message_test, broadcast_message_test and create_message_flow_test.
- Add global message fixture.
- Add classroom_global_messsage_test for the model.
- Add global_message_policy_test.
- Add global_message_serializer test.